### PR TITLE
refactor: rename unclear methods, fix docstring typo

### DIFF
--- a/grunz/json_parser/json_parser.py
+++ b/grunz/json_parser/json_parser.py
@@ -75,17 +75,16 @@ class JSONParser:
         return animals
 
     @staticmethod
-    def get_file_paths_for_sort(list_of_detection_dicts: [Dict]) -> List:
+    def extract_file_paths(detection_results: List[Dict]) -> List[str]:
         """
-        :param list_of_detection_dicts: A list of dicts, i.e image objects containing animals..
+        :param detection_results: A list of dicts, i.e image objects containing animals.
         :return: A list of file paths for each positive result.
         """
-        return [d["file"] for d in list_of_detection_dicts]
+        return [d["file"] for d in detection_results]
 
     @staticmethod
-    def __convert_jpeg_path_to_original_avi(jpeg_path: str) -> str:
+    def __convert_jpeg_path_to_original_avi(jpeg_path: str) -> Path:
         """
-        A helper method to be used in `get_list_for_sort`.
         :param jpeg_path: Path to positive jpeg.
         :return: The path to the video from which the jpeg derives.
         """
@@ -100,9 +99,9 @@ class JSONParser:
         return Path(f"{original_dir}/{match.group(0)}")
 
     @staticmethod
-    def get_list_for_sort(jpeg_paths: List) -> List:
+    def convert_jpeg_paths_to_avi_paths(jpeg_paths: List[str]) -> List[Path]:
         """
-        :param jpeg_paths: A list of positive jpeg detention results.
-        :return: A list of paths which correspond to the avi file the jpeg was taken from.
+        :param jpeg_paths: A list of positive jpeg detection result paths.
+        :return: A list of paths which correspond to the AVI file each jpeg was taken from.
         """
         return [JSONParser.__convert_jpeg_path_to_original_avi(p) for p in jpeg_paths]

--- a/main.py
+++ b/main.py
@@ -78,10 +78,10 @@ def post_pro(mega_detector_json, output_dir: Path = None) -> None:
     json_parser = JSONParser(mega_detector_json)
 
     positive_detection_results = json_parser.filter_json_for_detection_results()
-    positive_jpeg_file_paths = json_parser.get_file_paths_for_sort(
+    positive_jpeg_file_paths = json_parser.extract_file_paths(
         positive_detection_results
     )
-    positive_avi_paths = json_parser.get_list_for_sort(positive_jpeg_file_paths)
+    positive_avi_paths = json_parser.convert_jpeg_paths_to_avi_paths(positive_jpeg_file_paths)
     avi_paths_set = file_utils.remove_duplicates_from_list(positive_avi_paths)
 
     for f in avi_paths_set:

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -13,10 +13,10 @@ class TestConvertJpegPathToAvi:
     def test_non_matching_filename_raises_value_error(self):
         """A JPEG path that doesn't contain a PICT*.AVI pattern should raise ValueError."""
         with pytest.raises(ValueError, match="Cannot extract AVI filename"):
-            JSONParser.get_list_for_sort(["some/path/random_image.jpeg"])
+            JSONParser.convert_jpeg_paths_to_avi_paths(["some/path/random_image.jpeg"])
 
     def test_matching_filename_still_works(self):
-        result = JSONParser.get_list_for_sort(["some/path/PICT0001.AVI-001.jpeg"])
+        result = JSONParser.convert_jpeg_paths_to_avi_paths(["some/path/PICT0001.AVI-001.jpeg"])
         assert len(result) == 1
         assert "PICT0001.AVI" in str(result[0])
 


### PR DESCRIPTION
## Summary

- **Rename `get_file_paths_for_sort`** to `extract_file_paths` — name now describes what it does.
- **Rename `get_list_for_sort`** to `convert_jpeg_paths_to_avi_paths` — name now describes the transformation.
- **Fix "detention" typo** in docstring (should be "detection").
- L5 (add `mega_detector_json` param doc) was already addressed in Phase 2.
- L3 (dissolve `FileUtils` class) deferred — the class still provides value as a namespace for `find_files_recursively` which uses instance state.

## Test plan

- [x] All callers updated: `main.py`, `test_path_safety.py`
- [x] Full suite: 50 passed, 0 regressions