### PR TITLE
Add missing lightning dependency for PytorchWildlife

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ matplotlib~=3.10
 pandas~=3.0
 requests~=2.32
 tqdm~=4.67
+lightning~=2.6
 
 # Dev
 pytest~=9.0


### PR DESCRIPTION
## Summary

- Add `lightning~=2.6` to `requirements.txt` — PytorchWildlife internally imports `from lightning import Trainer` but doesn't declare it as a dependency
- Fixes `ModuleNotFoundError: No module named 'lightning'` that was causing all 3 integration tests to error

## Test plan

- [x] `pytest tests/ -v` — 28 passed, 0 errors (previously 25 passed, 3 errors)