### PR TITLE
ci: add test workflow for PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest tests/ -m "not integration" -v


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` to run tests automatically
- Triggers on pull requests to main and pushes to main
- Runs `pytest tests/ -m "not integration"` on Python 3.12
- Integration tests excluded (require ~500MB model download)

## Test plan
- [x] YAML syntax is valid
- [x] Workflow will validate itself when this PR is opened