### PR TITLE
fix(deps): remove Pillow pin conflicting with moviepy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 PytorchWildlife~=1.2.4
 moviepy~=2.2
 numpy~=2.4
-Pillow>=12.1.1
 matplotlib~=3.10
 pandas~=3.0
 requests~=2.32


### PR DESCRIPTION
## Summary
- Removes `Pillow>=12.1.1` from `requirements.txt` which conflicts with `moviepy~=2.2` (`pillow<12.0`)
- Pillow is an indirect dependency — moviepy and PytorchWildlife declare their own constraints, so pip resolves correctly without an explicit pin

## Test plan
- [x] Local tests pass (25/25, 3 integration deselected)
- [x] CI should now resolve dependencies and run green