### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR do, and why? A sentence or two is fine. -->
+
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] CI/build
+- [ ] Dependencies
+
+## What's changed
+
+<!-- Bullet the key changes. Keep it brief — the diff tells the full story. -->
+
+-
+
+## Testing
+
+<!-- How did you verify this works? Mention any new or updated tests. -->
+
+-
+
+## Anything else?
+
+<!-- Optional: impact on other parts of the codebase, related issues, screenshots, etc. -->
+


### PR DESCRIPTION
## Summary

Adds a PR template so all future pull requests follow a consistent, friendly format.

## Type of change

- [x] Documentation

## What's changed

- Added `.github/PULL_REQUEST_TEMPLATE.md` with sections for summary, type of change, what's changed, testing, and optional notes
- Template is intentionally lightweight to suit the project's size

## Testing

- No code changes, so no tests needed. GitHub will auto-populate this template on the next PR to verify it works.

## Anything else?

This PR is the first to use the new template format.